### PR TITLE
Travis configuration file for continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: c
+compiler: gcc
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq gnome-common libglib2.0-dev gobject-introspection gtk-doc-tools libgudev-1.0-dev libpolkit-gobject-1-dev libpolkit-agent-1-dev
+script: ./autogen.sh && make distcheck


### PR DESCRIPTION
After merging this it would be great to add the Travis CI webhook to the printerd repo to enable it.

This replaces pull request #24 with a new branch that just has the one commit. The reason for the multiple commits before was having to test with published github branches.
